### PR TITLE
Potential fix for code scanning alert no. 4: Stored cross-site scripting

### DIFF
--- a/src/app/[locale]/posts/page.tsx
+++ b/src/app/[locale]/posts/page.tsx
@@ -34,7 +34,7 @@ export default async function Posts(props: {
           {postList.length === 0 && <p>{t('no-posts-found')}</p>}
           {postList.map(({ id, date, title, tags }) => (
             <li key={id}>
-              <Link href={`/${locale}/posts/${id}`}>
+              <Link href={`/${locale}/posts/${encodeURIComponent(id)}`}>
                 <div className="post-card">
                   <div className="post-title">{title}</div>
                   <div className="post-date-tags-container">

--- a/src/libs/contents.ts
+++ b/src/libs/contents.ts
@@ -41,6 +41,8 @@ export function getSortedContentsData(subDirectory: string, locale: string) {
       id = id.replace(`${pattern[1]}-`, '')
     }
 
+    id = id.replace(/[^a-zA-Z0-9_-]/g, '')
+
     const tags: string[] = matterResult.data.tags
       ? (matterResult.data.tags + '').split(',')
       : []


### PR DESCRIPTION
Potential fix for [https://github.com/yiRMT/yiwashita.com/security/code-scanning/4](https://github.com/yiRMT/yiwashita.com/security/code-scanning/4)

General fix: ensure stored identifiers from filenames are validated/sanitized to an allowlist format before they are returned/used, and URL-encode when building links.

Best minimal fix without changing intended functionality:
1. In `src/libs/contents.ts`, sanitize `id` right after extraction so only safe slug characters remain (letters, digits, `_`, `-`). This prevents unsafe characters from propagating anywhere else.
2. In `src/app/[locale]/posts/page.tsx`, defensively encode the path segment with `encodeURIComponent(id)` when building `href`.

This keeps behavior (slug-based routing) while removing dangerous characters and ensuring safe URL construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
