### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           branch: ${{ github.head_ref }}
   eslint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/yiRMT/yiwashita.com/security/code-scanning/5](https://github.com/yiRMT/yiwashita.com/security/code-scanning/5)

Add an explicit `permissions` block to the `eslint` job in `.github/workflows/ci.yml`.

Best fix without changing functionality:
- Keep existing `prettier` permissions unchanged.
- Add minimal explicit permissions for `eslint`:
  - `contents: read` (needed for checkout/read access)
  - `pull-requests: write` (needed for `github-pr-review` comments on PRs)

This addresses the CodeQL warning and preserves current behavior for review comments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
